### PR TITLE
Added SetDatePickerMinuteIntervalXC to ControlExtensionsXC

### DIFF
--- a/iOSDesignExtensions/ControlExtensionsXC.xojo_code
+++ b/iOSDesignExtensions/ControlExtensionsXC.xojo_code
@@ -322,6 +322,15 @@ Protected Module ControlExtensionsXC
 	#tag EndMethod
 
 	#tag Method, Flags = &h0
+		Sub SetDatePickerMinuteIntervalXC(Extends datepicker As MobileDateTimePicker, interval As Integer)
+		  Declare Sub minuteInterval Lib "UIKit.framework" Selector "setMinuteInterval:" (obj As ptr, interval As Integer)
+		  
+		  minuteInterval(datepicker.Handle, interval)
+		  
+		End Sub
+	#tag EndMethod
+
+	#tag Method, Flags = &h0
 		Sub SetDatePickerStyleXC(extends datepicker As MobileDateTimePicker, style As ControlExtensionsXC.UIDatePickerStyle)
 		  
 		  if ExtensionsXC.GetiOSVersionXC >= 13.4 then


### PR DESCRIPTION
I want to be able to specify the minutes interval for a MobileDateTimePicker so that it behaves like the one in Apple's Calendar app which has a 5-minute interval by default in order to make it faster for my users to enter times.